### PR TITLE
release: JustScrape v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to JustScrape are documented here.
 - **JS fallback test mocking wrong module path** — `test_scrape_falls_back_to_javascript_when_static_is_thin` mocked `sys.modules["js_scraper"]` but the actual import is `justscrape.js_scraper` (relative). Also updated to match the current `scrape()` code path which calls `fetch()` + manual extraction instead of `static_scraper.scrape()`.
 
 ### Infrastructure
-- **235 tests passing** across 17 test files (up from 219/235)
+- **235 tests passing** across 16 test files (up from 219/235)
 
 ## [2.0.1] — 2026-03-30
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ Your AI asks "what's the difference between `dict.get()` and `dict[]` in Python?
 
 **Result:** 3 scored results, ~1,000 tokens of precisely targeted content instead of ~5,000+ tokens of raw page dumps.
 
+### Fast Lane (v2.0.2+)
+
+Not every query needs the full treatment. Simple queries like "pizza delivery near me" or "weather in london" skip the heavy pipeline entirely:
+
+- **Fast lane** (general/lookup intent, no entities): search + basic scrape + simple relevance sort. No reranking, no BM25, no dedup.
+- **Full pipeline** (code, research, comparison, how-to, news): all six stages above.
+
+The QueryAnalyzer decides which path to use automatically. Responses include `"fast_lane": true` so you can see which path ran.
+
 ```json
 {
   "query": "python dict.get() vs [] KeyError",
@@ -196,7 +205,7 @@ Your AI asks "what's the difference between `dict.get()` and `dict[]` in Python?
 | `research_with_sources` | Recommended default for question answering: search, retrieve, classify, and separate usable sources from failures |
 | `retrieve_source` | Retrieve one URL with explicit classification (`usable`, `thin`, `blocked`, `encoding-failure`, `empty`) |
 | `search_sources` | Search-only discovery tool that should usually be followed by retrieval, not more search loops |
-| `search_and_scrape` | Full pipeline — search, rerank, scrape, extract, score, dedup |
+| `search_and_scrape` | Full pipeline for complex queries; fast lane for simple ones (auto-routed) |
 | `web_search` | Search results only, no scraping |
 | `scrape_url` | Scrape a single URL to clean text |
 | `extract_urls` | Pull all links from a page |

--- a/mcp.json
+++ b/mcp.json
@@ -208,6 +208,85 @@
       }
     },
 
+    "search_and_scrape": {
+      "description": "Search + scrape in one call. Simple queries (general lookups, weather) use a fast lane that skips reranking, snippet extraction, quality scoring, and dedup. Complex queries (code, research, comparisons, how-to, news) use the full six-stage quality pipeline. Legacy alias: prefer research_with_sources for new integrations.",
+      "input": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search query (max 1000 chars)"
+          },
+          "num_results": {
+            "type": "integer",
+            "default": 3,
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Number of results to return"
+          },
+          "max_content_length": {
+            "type": "integer",
+            "default": 5000,
+            "description": "Truncate content beyond this length"
+          },
+          "site": {
+            "type": ["string", "null"],
+            "description": "Restrict search to a specific domain"
+          },
+          "date_range": {
+            "type": ["string", "null"],
+            "description": "Restrict search to a date range"
+          }
+        },
+        "required": ["query"]
+      },
+      "output": {
+        "type": "object",
+        "properties": {
+          "success": { "type": "boolean" },
+          "query": { "type": "string" },
+          "fast_lane": {
+            "type": "boolean",
+            "description": "True when the query was routed to the lightweight fast lane (general/lookup intent, no entities). Absent or false for full pipeline."
+          },
+          "query_intent": {
+            "type": "string",
+            "description": "Classified intent (code, research, news, how-to, lookup, comparison, general). Present only on fast lane responses."
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "position": { "type": "integer" },
+                "title": { "type": ["string", "null"] },
+                "url": { "type": "string", "format": "uri" },
+                "content": { "type": ["string", "null"] },
+                "best_sentence": { "type": ["string", "null"] },
+                "content_length": { "type": "integer" },
+                "relevance_score": { "type": "number" },
+                "score_breakdown": {
+                  "type": "object",
+                  "description": "Full pipeline only. Absent on fast lane results."
+                },
+                "source_type": { "type": "string" },
+                "detected_date": { "type": ["string", "null"] },
+                "confidence": { "type": "number" },
+                "scraped_successfully": { "type": "boolean" },
+                "fast_lane": { "type": "boolean", "description": "Per-result fast lane indicator" }
+              }
+            }
+          },
+          "skipped": { "type": "array", "description": "URLs filtered before scraping (blocked domains, etc.)" },
+          "total_results": { "type": "integer" },
+          "total_skipped": { "type": "integer" },
+          "search_time_ms": { "type": "integer" },
+          "search_cached": { "type": "boolean" }
+        },
+        "required": ["success", "query", "results"]
+      }
+    },
+
     "extract_urls": {
       "description": "Extract links from a page. No content classification.",
       "input": {


### PR DESCRIPTION
## Summary

- **Fast lane for simple queries** — general/lookup queries skip reranking, BM25/TF-IDF snippet extraction, quality scoring, and dedup. Complex queries (code, research, comparison, how-to, news) still use full pipeline. Auto-routed via QueryAnalyzer.
- **Fix 16 failing tests** — all failures were DNS resolution in sandboxed environments. Mocked `socket.getaddrinfo` and `validate_url` where needed.
- **Docs** — `search_and_scrape` tool + `fast_lane` field added to mcp.json schema. README updated with fast lane section.

## Test plan

- [x] 235/235 tests passing locally
- [x] CI green on this branch

https://claude.ai/code/session_01GU1Pvm5vGHeVMPj4We19GZ